### PR TITLE
fix for incomplete WeatherSync message missing tomorrowTemps

### DIFF
--- a/ClimatesOfFerngill/Weathers/WeatherConditions.cs
+++ b/ClimatesOfFerngill/Weathers/WeatherConditions.cs
@@ -622,32 +622,7 @@ namespace ClimatesOfFerngillRebuild
             if (!Context.IsMainPlayer)
                 return;
 
-            WeatherSync Message = new WeatherSync
-            {
-                weatherType = WeatherUtilities.GetWeatherCode(),
-                isFoggy = GetWeatherStatus("Fog"),
-                isThunderFrenzy = GetWeatherStatus("ThunderFrenzy"),
-                isWhiteOut = GetWeatherStatus("WhiteOut"),
-                isBlizzard = GetWeatherStatus("Blizzard"),
-                isSandstorm = GetWeatherStatus("Sandstorm"),
-                isVariableRain = IsVariableRain,
-                isOvercast = ((CurrentConditionsN & CurrentWeather.Overcast) != 0),
-                fogWeatherBeginTime = GetWeatherBeginTime("Fog").ReturnIntTime(),
-                thunWeatherBeginTime = GetWeatherBeginTime("ThunderFrenzy").ReturnIntTime(),
-                blizzWeatherBeginTime = GetWeatherBeginTime("Blizzard").ReturnIntTime(),
-                whiteWeatherBeginTime = GetWeatherBeginTime("WhiteOut").ReturnIntTime(),
-                sandstormWeatherBeginTime = GetWeatherBeginTime("Sandstorm").ReturnIntTime(),
-                sandstormWeatherEndTime = GetWeatherEndTime("Sandstorm").ReturnIntTime(),
-                fogWeatherEndTime = GetWeatherEndTime("Fog").ReturnIntTime(),
-                thunWeatherEndTime = GetWeatherEndTime("ThunderFrenzy").ReturnIntTime(),
-                blizzWeatherEndTime = GetWeatherEndTime("Blizzard").ReturnIntTime(),
-                whiteWeatherEndTime = GetWeatherEndTime("WhiteOut").ReturnIntTime(),
-                RainStatus = RainStatus,
-                rainAmt = AmtOfRainDrops,
-                todayHigh = TodayTemps.HigherBound,
-                todayLow = TodayTemps.LowerBound,
-                currTracker = new ClimateTracker(trackerModel)
-            };    
+            WeatherSync Message = GenerateWeatherSyncMessage();
 
             ClimatesOfFerngill.MPHandler.SendMessage<WeatherSync>(Message, "WeatherSync", new [] { "KoihimeNakamura.ClimatesOfFerngill" });    
         }


### PR DESCRIPTION
The WeatherSync message was created in to different places. The removed code was missing the tomorrowTemps fields so I replaced it with a function call that was already returning the correct values.